### PR TITLE
set MANPATH in a better way

### DIFF
--- a/npm-global-without-sudo.md
+++ b/npm-global-without-sudo.md
@@ -25,9 +25,9 @@ NPM_PACKAGES="${HOME}/.npm-packages"
 
 export PATH="$NPM_PACKAGES/bin:$PATH"
 
-# Unset manpath so we can inherit from /etc/manpath via the `manpath` command
-unset MANPATH # delete if you already modified MANPATH elsewhere in your config
-export MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
+# Preserve MANPATH if you already defined it somewhere in your config.
+# Otherwise fallback to `manpath` so we can inherit from /etc/manpath.
+export MANPATH="${MANPATH-$(manpath)}:$NPM_PACKAGES/share/man"
 ```
 
 ---


### PR DESCRIPTION
Setting MANPATH for npm should not clear user-defined settings. This shell syntax uses variable default value mechanism `${VAR-default}`.